### PR TITLE
Add counters to icons w-out functionality

### DIFF
--- a/frontend/src/components/Header/Header.module.scss
+++ b/frontend/src/components/Header/Header.module.scss
@@ -1,5 +1,6 @@
 @import '../../styles/_utils//mixins';
 @import '../../styles/_utils/_variables';
+@import '../../styles/_utils//extends';
 
 .header {
   position: sticky;
@@ -110,6 +111,61 @@
     display: grid;
     place-content: center;
     border-left: 1px solid #E2E6E9;
+  }
+}
+
+.header_fav_counter {
+  visibility: hidden;
+  @extend %header_fav_counter;
+
+  &_active {
+    visibility: visible;
+
+    @extend %header_fav_counter
+  }
+}
+
+.header_cart_counter {
+  @extend %header_fav_counter;
+  visibility: hidden;
+  right: 10px;
+
+  &_active {
+    visibility: visible;
+    right: 10px;
+
+    @extend %header_fav_counter;
+  }
+}
+
+.header_icon_counter {
+  visibility: hidden;
+  position: absolute;
+  background-color: $icon-counter-clr;
+
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  text-align: center;
+
+  color: #FFFFFF;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 2px;
+
+  right: 62px;
+  top: 12px;
+
+  z-index: 1;
+
+  &_active {
+    visibility: visible;
+
+    @extend %header_fav_counter;
+
+    @include onTablet {
+      display: none;
+    }
   }
 }
 
@@ -271,14 +327,23 @@
   display: flex;
   flex-basis: 50%;
   justify-content: center;
+
   border-right: 1px solid #e2e6e9;
 }
 
 .burger__cart_icon_link {
+  position: relative;
   padding: 25px 90px;
 }
 
-.burger__menu_footer_pic:hover {
-  border-bottom: 4px solid $grey-primary-clr;
+.burger_fav_counter {
+  visibility: hidden;
+  @extend %burger_fav_counter;
+
+  &_active {
+    visibility: visible;
+
+    @extend %burger_fav_counter;
+  }
 }
 

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -83,6 +83,9 @@ export const Header = React.memo(function Header() {
 
       <div className={styles.header_icons_container}>
         <div className={styles.header__cart_icon}>
+          <div className={styles.header_fav_counter}>
+          20
+          </div>
           <NavLink
             to="favourites"
             className={({ isActive }) => classNames(
@@ -96,6 +99,9 @@ export const Header = React.memo(function Header() {
         </div>
 
         <div className={styles.header__cart_icon}>
+          <div className={styles.header_cart_counter_active}>
+          11
+          </div>
           <NavLink
             to="cart"
             className={({ isActive }) => classNames(
@@ -199,6 +205,9 @@ export const Header = React.memo(function Header() {
               className={styles.burger__cart_icon_link}
             >
               <img src={favicon} alt="facourite_icon"/>
+              <div className={styles.burger_fav_counter}>
+                1
+              </div>
             </NavLink>
           </div>
 
@@ -209,7 +218,9 @@ export const Header = React.memo(function Header() {
               className={styles.burger__cart_icon_link}
             >
               <img src={cart} alt="shopping_cart_icon"/>
-
+              <div className={styles.burger_fav_counter_active}>
+                10
+              </div>
             </NavLink>
           </div>
         </footer>

--- a/frontend/src/styles/_utils/_extends.scss
+++ b/frontend/src/styles/_utils/_extends.scss
@@ -14,3 +14,45 @@
   transition: border-color 0.3s;
   border-radius: 50%;
 }
+
+%header_fav_counter {
+  position: absolute;
+  background-color: $icon-counter-clr;
+
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  text-align: center;
+
+  color: #FFFFFF;
+  font-size: 8px;
+  font-weight: 600;
+  padding: 1.5px;
+
+  right: 62px;
+  top: 12px;
+  border: 1px solid #FFFFFF;
+
+  z-index: 1;
+}
+
+%burger_fav_counter {
+  position: absolute;
+  background-color: $icon-counter-clr;
+
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  text-align: center;
+
+  color: #FFFFFF;
+  font-size: 8px;
+  font-weight: 600;
+  padding: 1.5px;
+
+  left: 100px;
+  bottom: 28px;
+  border: 1px solid #FFFFFF;
+
+  z-index: 1;
+}

--- a/frontend/src/styles/_utils/_variables.scss
+++ b/frontend/src/styles/_utils/_variables.scss
@@ -3,6 +3,7 @@ $white-primary-clr: #fff;
 $grey-primary-clr: #0F0F11;
 $grey-secondary-clr: #89939A;
 $accent-color: #F86800;
+$icon-counter-clr: #476DF4;
 $phonesCard-width-heigh-px: 16px;
 
 $padding-l-r-big: 24px;


### PR DESCRIPTION
Classes for header:
header_fav_counter  && header_fav_counter_active
header_cart_counter && header_cart_counter_active

classes for 2 icons in footer:
burger_fav_counter && burger_fav_counter_active
<img width="764" alt="Знімок екрана 2022-11-03 о 15 43 19" src="https://user-images.githubusercontent.com/108477341/199738684-dd63f974-1f81-4a71-bf46-2ef9b49db23d.png">

